### PR TITLE
bot: Duel listing commands #2

### DIFF
--- a/discord-bot/src/commands/duel.ts
+++ b/discord-bot/src/commands/duel.ts
@@ -1,0 +1,65 @@
+import { Command } from "@sapphire/framework";
+import { getChallengesById, getChallengesByState } from "../queries/getChallenges.js";
+import { ChallengeState } from "../utils/constants.js";
+import { formatDuelsAsEmbeds } from "../utils/challenges.js";
+import { Challenge } from "../generated/graphql.js";
+import { getDuelistByAddress } from '../queries/getChallenges.js';
+
+
+export class Duels_By_DuelistCommand extends Command {
+    public constructor(context: Command.LoaderContext, options?: Command.Options) {
+        super(context, {
+            ...options,
+            description: "display a specific duel",
+        });
+    }
+
+    public override registerApplicationCommands(registry: Command.Registry) {
+        registry.registerChatInputCommand(builder =>
+            builder
+                .setName("duel")
+                .setDescription(this.description)
+                .addStringOption((opt) => opt
+                    .setName("duel_id")
+                    .setDescription("duel_id")
+                    .setRequired(true)
+                )
+        );
+    }
+
+    public override async chatInputRun(interaction: Command.ChatInputCommandInteraction) {
+        const duel_id = interaction.options.getString("duel_id");
+
+        await interaction.deferReply();
+
+        try {
+            const allChallenges: Challenge[] = await getChallengesById(duel_id);
+            const relevantChallenges = allChallenges.filter(challenge =>
+                challenge.duel_id == duel_id
+            );
+
+            if (relevantChallenges.length === 0) {
+                return interaction.editReply({ content: "No duel found!" });
+            }
+
+            const enrichedChallenges = await Promise.all(relevantChallenges.map(async (challenge) => {
+                const challenger = await getDuelistByAddress(challenge.duelist_a);
+                const challenged = await getDuelistByAddress(challenge.duelist_b);
+                return { ...challenge, duelist_a: challenger, duelist_b: challenged };
+            }));
+
+            // console.log(enrichedChallenges);
+            return interaction.editReply({
+                embeds: formatDuelsAsEmbeds({
+                    challenges: enrichedChallenges,
+                    title: `Duel ${duel_id?.substring(0, 6)}`
+                })
+            });
+
+        } catch (error) {
+            console.error("Failed to fetch specified duel:", error);
+            return interaction.editReply({ content: "An error occurred while fetching duels." });
+        }
+    }
+}
+

--- a/discord-bot/src/commands/duel.ts
+++ b/discord-bot/src/commands/duel.ts
@@ -17,7 +17,7 @@ export class Duels_By_DuelistCommand extends Command {
     public override registerApplicationCommands(registry: Command.Registry) {
         registry.registerChatInputCommand(builder =>
             builder
-                .setName("duel")
+                .setName(this.name)
                 .setDescription(this.description)
                 .addStringOption((opt) => opt
                     .setName("duel_id")

--- a/discord-bot/src/commands/duel.ts
+++ b/discord-bot/src/commands/duel.ts
@@ -1,9 +1,8 @@
 import { Command } from "@sapphire/framework";
-import { getChallengesById, getChallengesByState } from "../queries/getChallenges.js";
-import { ChallengeState } from "../utils/constants.js";
+import { getChallengesById } from "../queries/getChallenges.js";
+import { getDuelistByAddress } from '../queries/getDuelists.js';
 import { formatDuelsAsEmbeds } from "../utils/challenges.js";
 import { Challenge } from "../generated/graphql.js";
-import { getDuelistByAddress } from '../queries/getChallenges.js';
 
 
 export class Duels_By_DuelistCommand extends Command {

--- a/discord-bot/src/commands/duelists.ts
+++ b/discord-bot/src/commands/duelists.ts
@@ -1,5 +1,5 @@
 import { Command } from "@sapphire/framework";
-import { getDuelist } from "../queries/getDuelists.js";
+import { getDuelistByAddress } from "../queries/getDuelists.js";
 import { formatDuelistsAsEmbeds } from "../utils/duelists.js";
 import { Duelist } from "../generated/graphql.js";
 import { bigintToHex } from "../utils/misc.js";
@@ -41,7 +41,7 @@ export class DuelistsCommand extends Command {
     }
 
     try {
-      const duelist: Duelist | null = await getDuelist(address);
+      const duelist: Duelist | null = await getDuelistByAddress(address);
 
       if (duelist) {
         const embeds = formatDuelistsAsEmbeds({

--- a/discord-bot/src/commands/duels_by_duelist.ts
+++ b/discord-bot/src/commands/duels_by_duelist.ts
@@ -17,7 +17,7 @@ export class Duels_By_DuelistCommand extends Command {
     public override registerApplicationCommands(registry: Command.Registry) {
         registry.registerChatInputCommand(builder =>
             builder
-                .setName("duels_by_duelist")
+                .setName(this.name)
                 .setDescription(this.description)
                 .addStringOption((opt) => opt
                     .setName("address")

--- a/discord-bot/src/commands/duels_by_duelist.ts
+++ b/discord-bot/src/commands/duels_by_duelist.ts
@@ -1,9 +1,9 @@
 import { Command } from "@sapphire/framework";
 import { getChallengesByState } from "../queries/getChallenges.js";
-import { ChallengeState } from "../utils/constants.js";
+import { getDuelistByAddress } from '../queries/getDuelists.js';
 import { formatChallengesAsEmbeds } from "../utils/challenges.js";
+import { ChallengeState } from "../utils/constants.js";
 import { Challenge } from "../generated/graphql.js";
-import { getDuelistByAddress } from '../queries/getChallenges.js';
 
 
 export class Duels_By_DuelistCommand extends Command {

--- a/discord-bot/src/commands/duels_by_duelist.ts
+++ b/discord-bot/src/commands/duels_by_duelist.ts
@@ -1,0 +1,70 @@
+import { Command } from "@sapphire/framework";
+import { getChallengesByState } from "../queries/getChallenges.js";
+import { ChallengeState } from "../utils/constants.js";
+import { formatChallengesAsEmbeds } from "../utils/challenges.js";
+import { Challenge } from "../generated/graphql.js";
+import { getDuelistByAddress } from '../queries/getChallenges.js';
+
+
+export class Duels_By_DuelistCommand extends Command {
+    public constructor(context: Command.LoaderContext, options?: Command.Options) {
+        super(context, {
+            ...options,
+            description: "List live duels by a duelist",
+        });
+    }
+
+    public override registerApplicationCommands(registry: Command.Registry) {
+        registry.registerChatInputCommand(builder =>
+            builder
+                .setName("duels_by_duelist")
+                .setDescription(this.description)
+                .addStringOption((opt) => opt
+                    .setName("address")
+                    .setDescription("Duelist Address")
+                    .setRequired(true)
+                )
+                .addIntegerOption((opt) => opt
+                .setName('page')
+                .setDescription('page number')
+                .setRequired(false)
+            )
+        );
+    }
+
+    public override async chatInputRun(interaction: Command.ChatInputCommandInteraction) {
+        const address = interaction.options.getString("address");
+
+        await interaction.deferReply();
+
+        try {
+            const allChallenges: Challenge[] = await getChallengesByState(ChallengeState.InProgress);
+            const relevantChallenges = allChallenges.filter(challenge =>
+                challenge.duelist_a === address || challenge.duelist_b === address
+            );
+
+            if (relevantChallenges.length === 0) {
+                return interaction.editReply({ content: "No duels found for this duelist!" });
+            }
+
+            // Fetching duelist data for each challenge and the profile of the duelist
+            const enrichedChallenges = await Promise.all(relevantChallenges.map(async (challenge) => {
+                const challenger = await getDuelistByAddress(challenge.duelist_a);
+                const challenged = await getDuelistByAddress(challenge.duelist_b);
+                return { ...challenge, duelist_a: challenger, duelist_b: challenged };
+            }));
+
+            return interaction.editReply({
+                embeds: formatChallengesAsEmbeds({
+                    challenges: enrichedChallenges,
+                    title: `Live Duels by ${address?.substring(0, 6)}`
+                })
+            });
+
+        } catch (error) {
+            console.error("Failed to fetch duels for the specified duelist:", error);
+            return interaction.editReply({ content: "An error occurred while fetching duels." });
+        }
+    }
+}
+

--- a/discord-bot/src/commands/live_duels.ts
+++ b/discord-bot/src/commands/live_duels.ts
@@ -1,9 +1,9 @@
 import { Command } from "@sapphire/framework";
 import { getChallengesByState } from "../queries/getChallenges.js";
-import { ChallengeState } from "../utils/constants.js";
+import { getDuelistByAddress } from '../queries/getDuelists.js';
 import { formatChallengesAsEmbeds } from "../utils/challenges.js";
+import { ChallengeState } from "../utils/constants.js";
 import { Challenge } from "../generated/graphql.js";
-import { getDuelistByAddress } from '../queries/getChallenges.js';
 
 export class LiveDuelsCommand extends Command {
     public constructor(context: Command.LoaderContext, options?: Command.Options) {

--- a/discord-bot/src/commands/live_duels.ts
+++ b/discord-bot/src/commands/live_duels.ts
@@ -16,7 +16,7 @@ export class LiveDuelsCommand extends Command {
     public override registerApplicationCommands(registry: Command.Registry) {
         registry.registerChatInputCommand(builder =>
             builder
-                .setName("liveduels")
+                .setName(this.name)
                 .setDescription(this.description)
         );
     }

--- a/discord-bot/src/graphql/getChallenges.graphql
+++ b/discord-bot/src/graphql/getChallenges.graphql
@@ -33,3 +33,22 @@ query getChallengesById($duel_id: u128!) {
     }
   }
 }
+
+query getDuelistsByAddress($address: ContractAddress) {
+  duelistModels(where: { address: $address }) {
+    edges {
+      node {
+        address
+        name
+        profile_pic
+        total_duels
+        total_wins
+        total_losses
+        total_draws
+        total_honour
+        honour
+        timestamp
+      }
+    }
+  }
+}

--- a/discord-bot/src/graphql/getChallenges.graphql
+++ b/discord-bot/src/graphql/getChallenges.graphql
@@ -33,22 +33,3 @@ query getChallengesById($duel_id: u128!) {
     }
   }
 }
-
-query getDuelistsByAddress($address: ContractAddress) {
-  duelistModels(where: { address: $address }) {
-    edges {
-      node {
-        address
-        name
-        profile_pic
-        total_duels
-        total_wins
-        total_losses
-        total_draws
-        total_honour
-        honour
-        timestamp
-      }
-    }
-  }
-}

--- a/discord-bot/src/queries/getChallenges.ts
+++ b/discord-bot/src/queries/getChallenges.ts
@@ -22,6 +22,16 @@ export const getChallengesById = async (duel_id: bigint): Promise<ql.Challenge[]
     }
 };
 
+export const getDuelistByAddress = async(address: any): Promise<ql.Duelist | null> => {
+    try{
+        const { data } = await sdk.getDuelistsByAddress({ address });
+        return parseDuelistResponse(data)
+    }catch(error){
+        console.error("getDuelistByAddress() failed!", error);
+        throw error;
+    }
+}
+
 const parseChallengesResponse = (data: ql.GetChallengesByStateQuery | ql.GetChallengesByIdQuery): ql.Challenge[] => {
     let result: ql.Challenge[] = []
     if (data?.challengeModels?.edges) {
@@ -29,9 +39,26 @@ const parseChallengesResponse = (data: ql.GetChallengesByStateQuery | ql.GetChal
             const challenge = item.node;
             return {
                 ...challenge,
-                message: feltToString(challenge.message), // strings in Cairo are encoded in a felt252, need to be convert
+                message: feltToString(challenge.message), 
             }
         });
     }
     return result
+};
+
+const parseDuelistResponse = (
+    data: ql.GetDuelistsByAddressQuery
+): ql.Duelist | null => {
+    if (
+        data?.duelistModels?.edges?.length &&
+        data.duelistModels.edges.length > 0
+    ) {
+        const duelist = data.duelistModels.edges[0]?.node;
+        if (duelist) {
+            return {
+                ...duelist,
+            };
+        }
+    }
+    return null;
 };

--- a/discord-bot/src/queries/getChallenges.ts
+++ b/discord-bot/src/queries/getChallenges.ts
@@ -12,7 +12,7 @@ export const getChallengesByState = async (state: number): Promise<ql.Challenge[
     }
 };
 
-export const getChallengesById = async (duel_id: bigint): Promise<ql.Challenge[]> => {
+export const getChallengesById = async (duel_id: any): Promise<ql.Challenge[]> => {
     try {
         const { data } = await sdk.getChallengesById({ duel_id });
         return parseChallengesResponse(data)

--- a/discord-bot/src/queries/getChallenges.ts
+++ b/discord-bot/src/queries/getChallenges.ts
@@ -22,16 +22,6 @@ export const getChallengesById = async (duel_id: any): Promise<ql.Challenge[]> =
     }
 };
 
-export const getDuelistByAddress = async(address: any): Promise<ql.Duelist | null> => {
-    try{
-        const { data } = await sdk.getDuelistsByAddress({ address });
-        return parseDuelistResponse(data)
-    }catch(error){
-        console.error("getDuelistByAddress() failed!", error);
-        throw error;
-    }
-}
-
 const parseChallengesResponse = (data: ql.GetChallengesByStateQuery | ql.GetChallengesByIdQuery): ql.Challenge[] => {
     let result: ql.Challenge[] = []
     if (data?.challengeModels?.edges) {
@@ -44,21 +34,4 @@ const parseChallengesResponse = (data: ql.GetChallengesByStateQuery | ql.GetChal
         });
     }
     return result
-};
-
-const parseDuelistResponse = (
-    data: ql.GetDuelistsByAddressQuery
-): ql.Duelist | null => {
-    if (
-        data?.duelistModels?.edges?.length &&
-        data.duelistModels.edges.length > 0
-    ) {
-        const duelist = data.duelistModels.edges[0]?.node;
-        if (duelist) {
-            return {
-                ...duelist,
-            };
-        }
-    }
-    return null;
 };

--- a/discord-bot/src/queries/getDuelists.ts
+++ b/discord-bot/src/queries/getDuelists.ts
@@ -1,30 +1,29 @@
-import * as gql from "../generated/graphql.js";
+import * as ql from "../generated/graphql.js";
 import { sdk } from "../config.js";
-import { feltToString } from "../utils/misc.js";
 
-export const getDuelist = async (address: any): Promise<gql.Duelist | null> => {
-  try {
-    const { data } = await sdk.getDuelistsByAddress({ address });
-    return parseDuelistResponse(data);
-  } catch (error) {
-    console.error("getDuelistByAddress() fetching error:", error);
-    throw error;
-  }
-};
+export const getDuelistByAddress = async (address: any): Promise<ql.Duelist | null> => {
+    try {
+        const { data } = await sdk.getDuelistsByAddress({ address });
+        return parseDuelistResponse(data)
+    } catch (error) {
+        console.error("getDuelistByAddress() failed!", error);
+        throw error;
+    }
+}
 
 const parseDuelistResponse = (
-  data: gql.GetDuelistsByAddressQuery
-): gql.Duelist | null => {
-  if (
-    data?.duelistModels?.edges?.length &&
-    data.duelistModels.edges.length > 0
-  ) {
-    const duelist = data.duelistModels.edges[0]?.node;
-    if (duelist) {
-      return {
-        ...duelist,
-      };
+    data: ql.GetDuelistsByAddressQuery
+): ql.Duelist | null => {
+    if (
+        data?.duelistModels?.edges?.length &&
+        data.duelistModels.edges.length > 0
+    ) {
+        const duelist = data.duelistModels.edges[0]?.node;
+        if (duelist) {
+            return {
+                ...duelist,
+            };
+        }
     }
-  }
-  return null;
+    return null;
 };

--- a/discord-bot/src/utils/challenges.ts
+++ b/discord-bot/src/utils/challenges.ts
@@ -54,7 +54,6 @@ export const formatChallengesAsEmbeds = ({
                 { name: 'Challenged', value: `${challengedName}\nHonour: ${challengedHonour / 10} ${challengedHonour > 90 ? " 👑" : ""}`, inline: true },
                 {name: 'Round Number', value:`${challenge.round_number}`},
                 { name: 'Duel Time', value: `${duel_time.toLocaleString()}`},
-                { name: `Duels by ${challengerName}`, value: `Type \`/duels_by_duelist \`` }
             );
         return embed;
     });

--- a/discord-bot/src/utils/challenges.ts
+++ b/discord-bot/src/utils/challenges.ts
@@ -2,6 +2,7 @@ import { APIEmbed, EmbedBuilder } from "discord.js";
 import { Challenge } from "../generated/graphql";
 import { Colors } from "./constants.js";
 import { feltToString } from "../utils/misc.js";
+import { url } from "inspector";
 //
 // Format Challenges as text message
 // 
@@ -38,7 +39,6 @@ export const formatChallengesAsEmbeds = ({
     title?: string
 }): EmbedBuilder[] => {
     return challenges.map((challenge, index) => {
-        // Assuming duelist objects include properties like `name` and `honour`
         const challengerName = feltToString(challenge.duelist_a.name);
         const challengedName = feltToString(challenge.duelist_b.name);
         const challengerHonour = challenge.duelist_a.honour;
@@ -58,5 +58,42 @@ export const formatChallengesAsEmbeds = ({
         return embed;
     });
 }
+
+
+export const formatDuelsAsEmbeds = ({
+    challenges,
+    title = 'Duel',
+}: {
+    challenges: Challenge[],
+    title?: string
+}): EmbedBuilder[] => {
+    return challenges.map((challenge, index) => {
+        const challengerName = feltToString(challenge.duelist_a.name);
+        const challengedName = feltToString(challenge.duelist_b.name);
+        const challengerHonour = challenge.duelist_a.honour;
+        const challengedHonour = challenge.duelist_b.honour;
+        const duel_time = new Date(challenge.timestamp_start * 1000);
+        const url = `${process.env.CLIENT_URL}/profiles/0${challenge.duelist_a.profile_pic}_sq.jpg`
+        const url1 = `${process.env.CLIENT_URL}/profiles/0${challenge.duelist_b.profile_pic}_sq.jpg`
+
+        const embed = new EmbedBuilder()
+            .setColor(Colors.Positive)
+            .setTitle(`${title}`)
+            .setThumbnail(url)
+            .setDescription(`**Duel ID:** \`${challenge.duel_id.substring(0, 6)}\`.....`)
+            .addFields(
+                { name: 'Challenger', value: `${challengerName}\nHonour: ${challengerHonour / 10}  ${challengerHonour > 90 ? " 👑" : ""}`, inline: true },
+                { name: 'Challenged', value: `${challengedName}\nHonour: ${challengedHonour / 10} ${challengedHonour > 90 ? " 👑" : ""}`, inline: true },
+                { name: 'Round', value: `${challenge.round_number}` },
+                { name: 'Challenge', value: `${challenge.message}`, inline:true },
+                { name: 'Duel Time', value: `${duel_time.toLocaleString()}`, inline:true },
+                { name: 'For more?', value: 'use the /duelist command', inline:true },
+            )
+            .setImage(url1)
+            
+        return embed;
+    });
+}
+
 
 

--- a/social-app/pages/api/oauth.ts
+++ b/social-app/pages/api/oauth.ts
@@ -16,7 +16,7 @@ const JWT_SECRET = 'thisisasecret';
 // note: this should be an environment variable
 // but I'll cover that in part 2 since
 // it will work fine locally for the time being
-const REDIRECT_URI = 'http://localhost:3000/api/oauth';
+const REDIRECT_URI = process.env.NEXT_PUBLIC_REDIRECT_URI;
 
 // Scopes we want to be able to access as a user
 const scope = ['identify'].join(' ');

--- a/social-app/pages/index.tsx
+++ b/social-app/pages/index.tsx
@@ -7,15 +7,15 @@ import Logo from "@/components/Logo";
 export default function IndexPage() {
   const router = useRouter();
 
-  const handleLogin = () => {
-    router.push("/api/oauth");
-  };
+//   const handleLogin = () => {
+//     router.push("/api/oauth");
+//   };
 
   const _login = () => {
     const app_id = process.env.NEXT_PUBLIC_CLIENT_ID
     const redirect_uri = encodeURIComponent(process.env.NEXT_PUBLIC_REDIRECT_URI)
     const url = `https://discord.com/oauth2/authorize?client_id=${app_id}&response_type=code&redirect_uri=${redirect_uri}&scope=identify+email`
-    window.location.href = url
+    router.push(url)
   }
 
   return (


### PR DESCRIPTION
resolves #2 


 - [x] Improve live_duels command
- [x] Improve GraphQL query, crossing the Challenge and Duelist models.
- [x] Input: page (optional)
- [x] Display a compact table containing max 10 duels (configurable)
- [x] Pagination links, to display [next] 10 Duels (if available) and/or [previous] 10 Duels
- [x] Each line display 1 Duel, including:
    - Truncated Duel id (6 first hex) as a link that triggers the duel command
    - Wager value using a 💰
    - Current round number
    - Challenger Name, Honour, and 👑 badge (from the Duelist model)
    - Challenged Name, Honour, and 👑badge (from the Duelist model)
    - If duelists are wounded, display one blood drop 🩸 for each wound by their side
    - Duel elapsed time

- [x]  Create the duels_by_duelist command. Exactly like live_duels, but filters by duelist (duelist_a or duelist_b). Please do not to duplicate the whole command, create 2 entry points that generate the same result.
- [x]  Input: address
- [x]  Input: page (optional)

- [x]  Create the duel command
- [x]  Create GraphQL query from the Duelist model.
- [x]  Input: duel_id
- [x]  Display a compact table containing:
    - Truncated Duel id (6 first hex) as a link to the actual duel on the game
    - Challenger Name, Honour, 👑 badge, and square Profile Picture, with link to trigger the duelist command
    - Challenged Name, Honour, 👑 badge, and square Profile Picture, with link to trigger the duelist command
    - Wager value using a 💰
    - Duel actions so far (see references below)
    - Duel elapsed time
 
![image](https://github.com/underware-gg/pistols-discord-bot/assets/116242877/65ebac27-b43a-4087-b26a-4dd58f6aad96)

![image](https://github.com/underware-gg/pistols-discord-bot/assets/116242877/c80f5859-3ebc-45bf-ae41-d3cab309189e)
